### PR TITLE
Encoder namespace bug

### DIFF
--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -432,7 +432,7 @@ func (l loggable) MarshalLogArray(enc ArrayEncoder) error {
 	return nil
 }
 
-// maybeNamespace is an ObjectMarhsaler that sometimes opens a namespace
+// maybeNamespace is an ObjectMarshaler that sometimes opens a namespace
 type maybeNamespace struct{ bool }
 
 func (m maybeNamespace) MarshalLogObject(enc ObjectEncoder) error {

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -220,6 +220,22 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 				e.OpenNamespace("innermost")
 			},
 		},
+		{
+			desc:     "object (no nested namespace)",
+			expected: `"obj":{"obj-out":"obj-outside-namespace"},"not-obj":"should-be-outside-obj"`,
+			f: func(e Encoder) {
+				e.AddObject("obj", maybeNamespace{false})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+		},
+		{
+			desc:     "object (with nested namespace)",
+			expected: `"obj":{"obj-out":"obj-outside-namespace","obj-namespace":{"obj-in":"obj-inside-namespace"}},"not-obj":"should-be-outside-obj"`,
+			f: func(e Encoder) {
+				e.AddObject("obj", maybeNamespace{true})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -313,6 +329,22 @@ func TestJSONEncoderArrays(t *testing.T) {
 				)
 			},
 		},
+		{
+			desc:     "object (no nested namespace) then string",
+			expected: `[{"obj-out":"obj-outside-namespace"},"should-be-outside-obj",{"obj-out":"obj-outside-namespace"},"should-be-outside-obj"]`,
+			f: func(arr ArrayEncoder) {
+				arr.AppendObject(maybeNamespace{false})
+				arr.AppendString("should-be-outside-obj")
+			},
+		},
+		{
+			desc:     "object (with nested namespace) then string",
+			expected: `[{"obj-out":"obj-outside-namespace","obj-namespace":{"obj-in":"obj-inside-namespace"}},"should-be-outside-obj",{"obj-out":"obj-outside-namespace","obj-namespace":{"obj-in":"obj-inside-namespace"}},"should-be-outside-obj"]`,
+			f: func(arr ArrayEncoder) {
+				arr.AppendObject(maybeNamespace{true})
+				arr.AppendString("should-be-outside-obj")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -397,6 +429,18 @@ func (l loggable) MarshalLogArray(enc ArrayEncoder) error {
 		return errors.New("can't marshal")
 	}
 	enc.AppendBool(true)
+	return nil
+}
+
+// maybeNamespace is an ObjectMarhsaler that sometimes opens a namespace
+type maybeNamespace struct{ bool }
+
+func (m maybeNamespace) MarshalLogObject(enc ObjectEncoder) error {
+	enc.AddString("obj-out", "obj-outside-namespace")
+	if m.bool {
+		enc.OpenNamespace("obj-namespace")
+		enc.AddString("obj-in", "obj-inside-namespace")
+	}
 	return nil
 }
 

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -223,7 +223,9 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assertOutput(t, tt.desc, tt.expected, tt.f)
+		t.Run(tt.desc, func(t *testing.T) {
+			assertOutput(t, tt.desc, tt.expected, tt.f)
+		})
 	}
 }
 
@@ -314,16 +316,18 @@ func TestJSONEncoderArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		f := func(enc Encoder) error {
-			return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-				tt.f(arr)
-				tt.f(arr)
-				return nil
-			}))
-		}
-		assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
-			err := f(enc)
-			assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+		t.Run(tt.desc, func(t *testing.T) {
+			f := func(enc Encoder) error {
+				return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+					tt.f(arr)
+					tt.f(arr)
+					return nil
+				}))
+			}
+			assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
+				err := f(enc)
+				assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+			})
 		})
 	}
 }

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapObjectEncoderAdd(t *testing.T) {
@@ -204,9 +205,11 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		tt.f(enc)
-		assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			tt.f(enc)
+			assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		})
 	}
 }
 func TestSliceArrayEncoderAppend(t *testing.T) {
@@ -255,19 +258,18 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-			tt.f(arr)
-			tt.f(arr)
-			return nil
-		})), "Expected AddArray to succeed.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+				tt.f(arr)
+				tt.f(arr)
+				return nil
+			})), "Expected AddArray to succeed.")
 
-		arr, ok := enc.Fields["k"].([]interface{})
-		if !ok {
-			t.Errorf("Test case %s didn't encode an array.", tt.desc)
-			continue
-		}
-		assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+			arr, ok := enc.Fields["k"].([]interface{})
+			require.True(t, ok, "Test case %s didn't encode an array.", tt.desc)
+			assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+		})
 	}
 }
 

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -202,6 +202,37 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "object (no nested namespace) then string",
+			f: func(e ObjectEncoder) {
+				e.OpenNamespace("k")
+				e.AddObject("obj", maybeNamespace{false})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+			expected: map[string]interface{}{
+				"obj": map[string]interface{}{
+					"obj-out": "obj-outside-namespace",
+				},
+				"not-obj": "should-be-outside-obj",
+			},
+		},
+		{
+			desc: "object (with nested namespace) then string",
+			f: func(e ObjectEncoder) {
+				e.OpenNamespace("k")
+				e.AddObject("obj", maybeNamespace{true})
+				e.AddString("not-obj", "should-be-outside-obj")
+			},
+			expected: map[string]interface{}{
+				"obj": map[string]interface{}{
+					"obj-out": "obj-outside-namespace",
+					"obj-namespace": map[string]interface{}{
+						"obj-in": "obj-inside-namespace",
+					},
+				},
+				"not-obj": "should-be-outside-obj",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -254,6 +285,41 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 				}))
 			},
 			expected: []interface{}{true, false},
+		},
+		{
+			desc: "object (no nested namespace) then string",
+			f: func(e ArrayEncoder) {
+				e.AppendArray(ArrayMarshalerFunc(func(inner ArrayEncoder) error {
+					inner.AppendObject(maybeNamespace{false})
+					inner.AppendString("should-be-outside-obj")
+					return nil
+				}))
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"obj-out": "obj-outside-namespace",
+				},
+				"should-be-outside-obj",
+			},
+		},
+		{
+			desc: "object (with nested namespace) then string",
+			f: func(e ArrayEncoder) {
+				e.AppendArray(ArrayMarshalerFunc(func(inner ArrayEncoder) error {
+					inner.AppendObject(maybeNamespace{true})
+					inner.AppendString("should-be-outside-obj")
+					return nil
+				}))
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"obj-out": "obj-outside-namespace",
+					"obj-namespace": map[string]interface{}{
+						"obj-in": "obj-inside-namespace",
+					},
+				},
+				"should-be-outside-obj",
+			},
 		},
 	}
 


### PR DESCRIPTION
Demonstrate jsonEncoder and MapObjectEncoder differences
    
Add test cases to demonstrate https://github.com/uber-go/zap/issues/554,
how jsonEncoder and MapObjectEncoder handle namespaces differently.
    
Specifically: When foo.MarshalLogObject uses OpenNamespace,
jsonEncoder.AddObject does not close the namespace.